### PR TITLE
feat(support): rt-2299 allow custom settings

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/MoreSettings/SplitComponents/DesktopOptions.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/MoreSettings/SplitComponents/DesktopOptions.tsx
@@ -91,6 +91,7 @@ export const DesktopOptions = ({
   const toggleChat = useSidepaneToggle(SIDE_PANE_OPTIONS.CHAT);
   // Hide if pip chat is already open
   const showPipChatOption = !!elements?.chat && isSupported && !pipWindow;
+  const customOptions = elements?.settings?.customOptions;
 
   useDropdownList({ open: openModals.size > 0, name: 'MoreSettings' });
 
@@ -243,6 +244,14 @@ export const DesktopOptions = ({
                 </Text>
               </Dropdown.Item>
             ))}
+          {customOptions?.map(({ label, icon, onClick }) => (
+            <Dropdown.Item key={label} onClick={onClick}>
+              {icon}
+              <Text variant="sm" css={{ ml: '$4' }}>
+                {label}
+              </Text>
+            </Dropdown.Item>
+          ))}
         </Dropdown.Content>
       </Dropdown.Root>
       {openModals.has(MODALS.BULK_ROLE_CHANGE) && (

--- a/packages/roomkit-react/src/Prebuilt/components/MoreSettings/SplitComponents/MwebOptions.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/MoreSettings/SplitComponents/MwebOptions.tsx
@@ -313,7 +313,7 @@ export const MwebOptions = ({
               </ActionTile.Root>
             ) : null}
 
-            {(title || description) && !customOptions.length ? (
+            {(title || description) && !customOptions?.length ? (
               <ActionTile.Root
                 onClick={() => {
                   setOpenOptionsSheet(false);
@@ -325,7 +325,13 @@ export const MwebOptions = ({
               </ActionTile.Root>
             ) : null}
             {customOptions?.map(({ label, icon, onClick }) => (
-              <ActionTile.Root key={label} onClick={onClick}>
+              <ActionTile.Root
+                key={label}
+                onClick={() => {
+                  onClick();
+                  setOpenOptionsSheet(false);
+                }}
+              >
                 {icon}
                 <ActionTile.Title>{label}</ActionTile.Title>
               </ActionTile.Root>

--- a/packages/roomkit-react/src/Prebuilt/components/MoreSettings/SplitComponents/MwebOptions.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/MoreSettings/SplitComponents/MwebOptions.tsx
@@ -115,6 +115,7 @@ export const MwebOptions = ({
   const { startRecording, isRecordingLoading } = useRecordingHandler();
   const isTranscriptionAllowed = useHMSStore(selectIsTranscriptionAllowedByMode(HMSTranscriptionMode.CAPTION));
   const isTranscriptionEnabled = useHMSStore(selectIsTranscriptionEnabled);
+  const customOptions = elements?.settings?.customOptions;
 
   const [isCaptionEnabled] = useSetIsCaptionEnabled();
   useDropdownList({ open: openModals.size > 0 || openOptionsSheet || openSettingsSheet, name: 'MoreSettings' });
@@ -312,7 +313,7 @@ export const MwebOptions = ({
               </ActionTile.Root>
             ) : null}
 
-            {title || description ? (
+            {(title || description) && !customOptions.length ? (
               <ActionTile.Root
                 onClick={() => {
                   setOpenOptionsSheet(false);
@@ -323,6 +324,12 @@ export const MwebOptions = ({
                 <ActionTile.Title>About Session</ActionTile.Title>
               </ActionTile.Root>
             ) : null}
+            {customOptions?.map(({ label, icon, onClick }) => (
+              <ActionTile.Root key={label} onClick={onClick}>
+                {icon}
+                <ActionTile.Title>{label}</ActionTile.Title>
+              </ActionTile.Root>
+            ))}
           </Box>
         </Sheet.Content>
       </Sheet.Root>

--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -289,7 +289,7 @@ export const PreviewControls = ({
         {isMobile && <NoiseCancellation iconOnly />}
         {!hideSettings ? <PreviewSettings /> : null}
         {customOptions?.map(({ label, icon, onClick }) => (
-          <IconButton key={label} css={{ flexShrink: 0 }} onClick={onClick} aria-label={label}>
+          <IconButton key={label} css={{ flexShrink: 0 }} onClick={onClick} aria-label={label} title={label}>
             {icon}
           </IconButton>
         ))}

--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { useMeasure, useMedia } from 'react-use';
+import type { DefaultPreviewScreen_Elements } from '@100mslive/types-prebuilt';
 import {
   HMSRoomState,
   selectAppData,
@@ -116,6 +117,7 @@ const PreviewJoin = ({
   const { elements = {} } = useRoomLayoutPreviewScreen();
   const { preview_header: previewHeader = {}, virtual_background } = elements || {};
   const aspectRatio = useLocalTileAspectRatio();
+  const customOptions = elements?.settings?.customOptions;
 
   useEffect(() => {
     if (authToken) {
@@ -163,7 +165,11 @@ const PreviewJoin = ({
         </Flex>
         {toggleVideo ? <PreviewTile name={name} error={previewError} /> : null}
         <Box css={{ w: '100%', maxWidth: `${Math.max(parseFloat(aspectRatio), 1) * 340}px` }}>
-          <PreviewControls hideSettings={!toggleVideo && !toggleAudio} vbEnabled={!!virtual_background} />
+          <PreviewControls
+            hideSettings={!toggleVideo && !toggleAudio}
+            vbEnabled={!!virtual_background}
+            customOptions={customOptions}
+          />
           <PreviewForm
             name={name}
             disabled={!!initialName}
@@ -257,7 +263,14 @@ export const PreviewTile = ({ name, error }: { name: string; error?: boolean }) 
   );
 };
 
-export const PreviewControls = ({ hideSettings, vbEnabled }: { hideSettings: boolean; vbEnabled: boolean }) => {
+export const PreviewControls = ({
+  hideSettings,
+  vbEnabled,
+  customOptions,
+}: DefaultPreviewScreen_Elements['settings'] & {
+  hideSettings: boolean;
+  vbEnabled: boolean;
+}) => {
   const isMobile = useMedia(cssConfig.media.md);
   const isVBEnabledForUser = useHMSStore(selectIsVBEnabled);
   return (
@@ -275,6 +288,11 @@ export const PreviewControls = ({ hideSettings, vbEnabled }: { hideSettings: boo
       <Flex align="center" gap="1">
         {isMobile && <NoiseCancellation iconOnly />}
         {!hideSettings ? <PreviewSettings /> : null}
+        {customOptions?.map(({ label, icon, onClick }) => (
+          <IconButton key={label} css={{ flexShrink: 0 }} onClick={onClick} aria-label={label}>
+            {icon}
+          </IconButton>
+        ))}
       </Flex>
     </Flex>
   );

--- a/packages/roomkit-react/src/Prebuilt/types.d.ts
+++ b/packages/roomkit-react/src/Prebuilt/types.d.ts
@@ -1,7 +1,28 @@
-import type { ReactNode } from 'react';
+import { ReactNode } from 'react';
+import '@100mslive/types-prebuilt';
 
 declare module '@100mslive/types-prebuilt/elements/participant_list' {
   export interface ParticipantList {
     footer?: ReactNode;
+  }
+}
+
+interface CustomSettingOption {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}
+
+interface SettingElements {
+  customOptions?: CustomSettingOption[];
+}
+
+declare module '@100mslive/types-prebuilt' {
+  export interface DefaultConferencingScreen_Elements {
+    settings?: SettingElements;
+  }
+
+  export interface DefaultPreviewScreen_Elements {
+    settings?: SettingElements;
   }
 }


### PR DESCRIPTION
# Description
RT-2299

- goal is to add a `troubleshooting & help` option in a few places

## Verify
- add the following to examples/prebuilt:
<img width="596" height="293" alt="image" src="https://github.com/user-attachments/assets/5fe04be2-28cb-4690-8f4b-e292409e2709" />

### Desktop
- in video, click hamburger menu to see:
<img width="405" height="549" alt="Screenshot 2025-10-31 at 9 59 12 AM" src="https://github.com/user-attachments/assets/46a176d4-7be2-40be-9161-f320faaaf856" />

- on preview screen:
<img width="550" height="229" alt="Screenshot 2025-10-31 at 10 04 31 AM" src="https://github.com/user-attachments/assets/64982dc7-6b3d-4c91-b6c3-b486d8651735" />

### Mobile
- in video, click hamburger menu to see:
<img width="586" height="474" alt="Screenshot 2025-10-31 at 9 59 23 AM" src="https://github.com/user-attachments/assets/d85afe32-5bc3-4cd7-af10-edca28563579" />

- on preview screen:
<img width="474" height="321" alt="Screenshot 2025-10-31 at 10 04 36 AM" src="https://github.com/user-attachments/assets/e7916f09-1da6-4306-ad24-0c42a905a019" />
