### PR TITLE
feat(preview): rt-3206 logo adornment

### DIFF
--- a/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
+++ b/packages/roomkit-react/src/Prebuilt/components/Preview/PreviewJoin.tsx
@@ -136,12 +136,22 @@ const PreviewJoin = ({
     }
   }, [initialName]);
 
+  // content should match <video> width, which is dynamic based on aspect ratio
+  const maxWidth = `${Math.max(parseFloat(aspectRatio), 1) * 340}px`;
+
   return roomState === HMSRoomState.Preview ? (
     <Flex justify="center" css={{ size: '100%', position: 'relative' }}>
       <Container css={{ h: '100%', pt: '$6', '@md': { justifyContent: 'space-between', pt: '$10' } }}>
         {toggleVideo ? null : <Box />}
         <Flex direction="column" justify="center" css={{ w: '100%', maxWidth: '600px', gap: '$8' }}>
-          <Logo />
+          {previewHeader.logoAdornment ? (
+            <Flex justify="center" css={{ w: '100%', maxWidth, position: 'relative', alignSelf: 'center' }}>
+              <Logo />
+              <Box css={{ position: 'absolute', right: 0 }}>{previewHeader.logoAdornment}</Box>
+            </Flex>
+          ) : (
+            <Logo />
+          )}
           <Text variant="h4" css={{ wordBreak: 'break-word', textAlign: 'center' }}>
             {previewHeader.title}
           </Text>
@@ -164,7 +174,7 @@ const PreviewJoin = ({
           </Flex>
         </Flex>
         {toggleVideo ? <PreviewTile name={name} error={previewError} /> : null}
-        <Box css={{ w: '100%', maxWidth: `${Math.max(parseFloat(aspectRatio), 1) * 340}px` }}>
+        <Box css={{ w: '100%', maxWidth }}>
           <PreviewControls
             hideSettings={!toggleVideo && !toggleAudio}
             vbEnabled={!!virtual_background}

--- a/packages/roomkit-react/src/Prebuilt/types.d.ts
+++ b/packages/roomkit-react/src/Prebuilt/types.d.ts
@@ -7,6 +7,12 @@ declare module '@100mslive/types-prebuilt/elements/participant_list' {
   }
 }
 
+declare module '@100mslive/types-prebuilt/elements/preview_header' {
+  export interface PreviewHeader {
+    logoAdornment?: ReactNode;
+  }
+}
+
 interface CustomSettingOption {
   icon: ReactNode;
   label: string;


### PR DESCRIPTION
RT-3206

## Verify
- in `examples/prebuilt`, add a custom logo adornment:
```ts
screens={{
  preview: {
    default: {
      elements: {
        preview_header: {
          logoAdornment: (
            <Flex align="center" css={{ backgroundColor: `#007d8a`, p: '$4 $6', gap: '$2', borderRadius: '$4' }}>
              <Text variant="sm" css={{ fontWeight: '$semiBold', color: '#fff' }}>
                BETA
              </Text>
            </Flex>
          ),
        },
      },
    },
  },
}}
```
![beta](https://github.com/user-attachments/assets/78e74763-4be4-4e80-b5cd-46959e3410d4)
